### PR TITLE
cpu: aarch64: improve memory management safety for jit_uni_softmax

### DIFF
--- a/src/cpu/aarch64/jit_uni_softmax.cpp
+++ b/src/cpu/aarch64/jit_uni_softmax.cpp
@@ -16,6 +16,7 @@
 *******************************************************************************/
 
 #include <assert.h>
+#include <memory>
 
 #include "common/c_types_map.hpp"
 #include "common/dnnl_thread.hpp"
@@ -668,12 +669,10 @@ struct jit_softmax_t<sve_128> : public jit_softmax_base_t<sve_128> {
 template <cpu_isa_t isa>
 jit_uni_softmax_fwd_t<isa>::jit_uni_softmax_fwd_t(const pd_t *apd)
     : primitive_t(apd)
-    , softmax_driver_(new softmax_impl::driver_t<isa>(pd())) {}
+    , softmax_driver_(utils::make_unique<softmax_impl::driver_t<isa>>(pd())) {}
 
 template <cpu_isa_t isa>
-jit_uni_softmax_fwd_t<isa>::~jit_uni_softmax_fwd_t() {
-    delete softmax_driver_;
-}
+jit_uni_softmax_fwd_t<isa>::~jit_uni_softmax_fwd_t() = default;
 
 template <cpu_isa_t isa>
 status_t jit_uni_softmax_fwd_t<isa>::init(engine_t *engine) {
@@ -725,12 +724,10 @@ status_t jit_uni_softmax_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
 template <cpu_isa_t isa>
 jit_uni_softmax_bwd_t<isa>::jit_uni_softmax_bwd_t(const pd_t *apd)
     : primitive_t(apd)
-    , softmax_driver_(new softmax_impl::driver_t<isa>(pd())) {}
+    , softmax_driver_(utils::make_unique<softmax_impl::driver_t<isa>>(pd())) {}
 
 template <cpu_isa_t isa>
-jit_uni_softmax_bwd_t<isa>::~jit_uni_softmax_bwd_t() {
-    delete softmax_driver_;
-}
+jit_uni_softmax_bwd_t<isa>::~jit_uni_softmax_bwd_t() = default;
 
 template <cpu_isa_t isa>
 status_t jit_uni_softmax_bwd_t<isa>::init(engine_t *engine) {

--- a/src/cpu/aarch64/jit_uni_softmax.hpp
+++ b/src/cpu/aarch64/jit_uni_softmax.hpp
@@ -19,6 +19,7 @@
 #define CPU_AARCH64_JIT_UNI_SOFTMAX_HPP
 
 #include <assert.h>
+#include <memory>
 
 #include "common/c_types_map.hpp"
 #include "common/memory_tracking.hpp"
@@ -119,7 +120,9 @@ struct jit_uni_softmax_fwd_t : public primitive_t {
 
 private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
-    softmax_impl::driver_t<isa> *softmax_driver_;
+    std::unique_ptr<softmax_impl::driver_t<isa>> softmax_driver_;
+
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_softmax_fwd_t);
 };
 
 template <cpu_isa_t isa>
@@ -191,7 +194,9 @@ struct jit_uni_softmax_bwd_t : public primitive_t {
 private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    softmax_impl::driver_t<isa> *softmax_driver_;
+    std::unique_ptr<softmax_impl::driver_t<isa>> softmax_driver_;
+
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_softmax_bwd_t);
 };
 
 } // namespace aarch64


### PR DESCRIPTION
on-behalf-of: @permanence-ai <github-ai@permanence.ai>

# Description

Please include a summary of the change. Please also include relevant motivation and context. See [contribution guidelines](https://github.com/oneapi-src/oneDNN/blob/master/CONTRIBUTING.md) for more details. If the change fixes an issue not documented in the project's Github issue tracker, please document all steps necessary to reproduce it.

Fixes # (github issue)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
